### PR TITLE
Implement the PUT /actions/{actionID}/rules/{ruleID} endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "John Watson <john.watson2@rpa.gov.uk>",
     "Mark Harrop <mark.harrop@defra.gov.uk>",
     "Matthew Collins <matthew.collins@defra.gov.uk>",
-    "David Bingham <david.bingham@defra.gov.uk>"
+    "David Bingham <david.bingham@defra.gov.uk>",
+    "Paul Andrews <paul.andrews@defra.gov.uk>"
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {

--- a/server/plugins/router.js
+++ b/server/plugins/router.js
@@ -1,4 +1,5 @@
 const routes = [].concat(
+  require('../routes/actionRules'),
   require('../routes/actions'),
   require('../routes/healthy'),
   require('../routes/healthz'),

--- a/server/routes/actionRules.js
+++ b/server/routes/actionRules.js
@@ -1,0 +1,28 @@
+const paramsSchema = require('../schema/actionRulesParams')
+const payloadSchema = require('../schema/actionRulesPayload')
+const actionRulesService = require('../services/actionRulesService')
+
+module.exports = {
+  method: 'PUT',
+  path: '/actions/{actionID}/{ruleID}',
+  options: {
+    validate: {
+      params: paramsSchema,
+      payload: payloadSchema,
+      failAction: async (request, h, error) => {
+        console.log('actionRules: failed validation')
+        console.log(`actionRules: actionID ${request.params.actionID}, rulesID ${request.params.ruleID}`)
+        console.log('actionRules: payload', request.payload)
+        return h.response().code(400).takeover()
+      }
+    },
+    handler: async (request, h) => {
+      const actionID = request.params.actionID
+      const ruleID = request.params.ruleID
+      const enabled = request.payload.enabled
+      console.log(`actionRules: set rule ${ruleID} on action ${actionID} to ${enabled}`)
+      const updatedRule = await actionRulesService.update(actionID, ruleID, enabled)
+      return h.response(updatedRule).code(200)
+    }
+  }
+}

--- a/server/routes/actionRules.js
+++ b/server/routes/actionRules.js
@@ -22,7 +22,7 @@ module.exports = {
       const enabled = request.payload.enabled
       console.log(`actionRules: set rule ${ruleID} on action ${actionID} to ${enabled}`)
       const updatedRule = await actionRulesService.update(actionID, ruleID, enabled)
-      return h.response(updatedRule).code(200)
+      return updatedRule ? h.response(updatedRule).code(200) : h.response().code(400)
     }
   }
 }

--- a/server/routes/actionRules.js
+++ b/server/routes/actionRules.js
@@ -4,7 +4,7 @@ const actionRulesService = require('../services/actionRulesService')
 
 module.exports = {
   method: 'PUT',
-  path: '/actions/{actionID}/{ruleID}',
+  path: '/actions/{actionID}/rules/{ruleID}',
   options: {
     validate: {
       params: paramsSchema,

--- a/server/schema/actionRulesParams.js
+++ b/server/schema/actionRulesParams.js
@@ -1,0 +1,6 @@
+const Joi = require('@hapi/joi')
+
+module.exports = Joi.object({
+  actionID: Joi.string().required(),
+  ruleID: Joi.number().required()
+})

--- a/server/schema/actionRulesPayload.js
+++ b/server/schema/actionRulesPayload.js
@@ -1,0 +1,5 @@
+const Joi = require('@hapi/joi')
+
+module.exports = Joi.object({
+  enabled: Joi.boolean().required()
+})

--- a/server/services/actionRulesService.js
+++ b/server/services/actionRulesService.js
@@ -1,0 +1,8 @@
+const rulesService = require('./rulesService')
+
+module.exports = {
+  update: async function (actionID, ruleID, enabled) {
+    // Throwing away the actionID at the moment as we assume only one action exists.
+    return rulesService.updateRuleEnabled(ruleID, enabled)
+  }
+}

--- a/server/services/parcelService.js
+++ b/server/services/parcelService.js
@@ -5,7 +5,7 @@ module.exports = {
     return parcels
   },
   getByRef: function (parcelRef) {
-    const matches = parcels.filter(parcel => parcel.parcelRef === parcelRef)
+    const matches = parcels.filter(parcel => parcel.ref === parcelRef)
     return matches.length ? matches[0] : null
   }
 }

--- a/server/services/rulesService.js
+++ b/server/services/rulesService.js
@@ -12,6 +12,6 @@ module.exports = {
       return rules[ruleIndex]
     }
 
-    return {}
+    return null
   }
 }

--- a/server/services/rulesService.js
+++ b/server/services/rulesService.js
@@ -6,7 +6,12 @@ module.exports = {
   },
   updateRuleEnabled: async function (ruleID, enabled) {
     const ruleIndex = rules.findIndex(rule => rule.id === ruleID)
-    rules[ruleIndex].enabled = enabled
-    return rules[ruleIndex]
+
+    if (ruleIndex > -1) {
+      rules[ruleIndex].enabled = enabled
+      return rules[ruleIndex]
+    }
+
+    return {}
   }
 }

--- a/server/services/rulesService.js
+++ b/server/services/rulesService.js
@@ -3,5 +3,10 @@ const rules = require('../../data/rules.json')
 module.exports = {
   get: async function () {
     return rules
+  },
+  updateRuleEnabled: async function (ruleID, enabled) {
+    const ruleIndex = rules.findIndex(rule => rule.id === ruleID)
+    rules[ruleIndex].enabled = enabled
+    return rules[ruleIndex]
   }
 }

--- a/test/routes/actionRules.test.js
+++ b/test/routes/actionRules.test.js
@@ -1,0 +1,77 @@
+describe('Action rules route test', () => {
+  let createServer
+  let server
+
+  const goodRequest = {
+    method: 'PUT',
+    url: '/actions/FG1/3',
+    payload: { enabled: true }
+  }
+
+  const badRequestParams = {
+    method: 'PUT',
+    url: '/actions/FG1/ABC',
+    payload: { enabled: true }
+  }
+
+  const badRequestPayload = {
+    method: 'PUT',
+    url: '/actions/FG1/3',
+    payload: { enabled: '123' }
+  }
+
+  const mockUpdatedRule = {
+    id: 3,
+    description: 'Rule description',
+    enabled: false,
+    facts: [{ description: 'Total Parcel Perimeter' }]
+  }
+
+  const mockActionRulesService = {
+    update: jest.fn().mockResolvedValue(mockUpdatedRule)
+  }
+
+  beforeAll(async () => {
+    jest.mock('../../server/services/actionRulesService', () => mockActionRulesService)
+    createServer = require('../../server/createServer')
+  })
+
+  beforeEach(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  test('calls the actionRulesService', async () => {
+    await server.inject(goodRequest)
+    expect(mockActionRulesService.update).toHaveBeenCalled()
+  })
+
+  test('returns the updated data from actionRulesService', async () => {
+    const response = await server.inject(goodRequest)
+    const payload = JSON.parse(response.payload)
+    expect(payload).toEqual(mockUpdatedRule)
+  })
+
+  test('responds with status code 200 for a well formed request', async () => {
+    const response = await server.inject(goodRequest)
+    expect(response.statusCode).toBe(200)
+  })
+
+  test('responds with status code 400 for a badly formed request params', async () => {
+    const response = await server.inject(badRequestParams)
+    expect(response.statusCode).toBe(400)
+  })
+
+  test('responds with status code 400 for a badly formed request payload', async () => {
+    const response = await server.inject(badRequestPayload)
+    expect(response.statusCode).toBe(400)
+  })
+
+  afterAll(() => {
+    jest.unmock('../../server/services/actionRulesService')
+  })
+
+  afterEach(async () => {
+    await server.stop()
+  })
+})

--- a/test/routes/actionRules.test.js
+++ b/test/routes/actionRules.test.js
@@ -4,19 +4,19 @@ describe('Action rules route test', () => {
 
   const goodRequest = {
     method: 'PUT',
-    url: '/actions/FG1/3',
+    url: '/actions/FG1/rules/3',
     payload: { enabled: true }
   }
 
   const badRequestParams = {
     method: 'PUT',
-    url: '/actions/FG1/ABC',
+    url: '/actions/FG1/rules/ABC',
     payload: { enabled: true }
   }
 
   const badRequestPayload = {
     method: 'PUT',
-    url: '/actions/FG1/3',
+    url: '/actions/FG1/rules/3',
     payload: { enabled: '123' }
   }
 

--- a/test/routes/actionRules.test.js
+++ b/test/routes/actionRules.test.js
@@ -2,9 +2,12 @@ describe('Action rules route test', () => {
   let createServer
   let server
 
+  const actionID = 'FG1'
+  const ruleID = 3
+
   const goodRequest = {
     method: 'PUT',
-    url: '/actions/FG1/rules/3',
+    url: `/actions/${actionID}/rules/${ruleID}`,
     payload: { enabled: true }
   }
 
@@ -43,7 +46,7 @@ describe('Action rules route test', () => {
 
   test('calls the actionRulesService', async () => {
     await server.inject(goodRequest)
-    expect(mockActionRulesService.update).toHaveBeenCalled()
+    expect(mockActionRulesService.update).toHaveBeenCalledWith(actionID, ruleID, goodRequest.payload.enabled)
   })
 
   test('returns the updated data from actionRulesService', async () => {

--- a/test/routes/parcelActions.test.js
+++ b/test/routes/parcelActions.test.js
@@ -55,7 +55,7 @@ describe('Parcel Actions route test', () => {
   })
 
   afterAll(() => {
-    jest.unmock('../../server/services/actionsService')
+    jest.unmock('../../server/services/parcelActionsService')
   })
 
   afterEach(async () => {

--- a/test/services/actionRulesService.test.js
+++ b/test/services/actionRulesService.test.js
@@ -16,18 +16,30 @@ jest.mock(
   ])
 )
 
+jest.mock('../../server/services/rulesService', () => ({
+  updateRuleEnabled: jest.fn()
+    .mockResolvedValueOnce(null)
+    .mockResolvedValueOnce({
+      id: 1,
+      description: 'Mock rule 1',
+      enabled: false,
+      facts: []
+    })
+}))
+
 describe('actionRulesService', () => {
-  test('action rules service returns empty object for unknown id', async () => {
+  test('update returns null for unknown rule id', async () => {
     const rule = await actionRulesService.update(mockActionID, -1, false)
-    expect(rule).toEqual(expect.any(Object))
+    expect(rule).toBeNull()
   })
 
-  test('action rules service returns a rule object containing given id and enabled state', async () => {
+  test('update returns a rule object containing given id and enabled state', async () => {
     const rule = await actionRulesService.update(mockActionID, mockRuleID, mockEnabledChange)
     expect(rule).toMatchObject({ id: mockRuleID, enabled: mockEnabledChange })
   })
 
   afterAll(() => {
     jest.unmock('../../data/rules.json')
+    jest.unmock('../../server/services/rulesService')
   })
 })

--- a/test/services/actionRulesService.test.js
+++ b/test/services/actionRulesService.test.js
@@ -1,37 +1,33 @@
 const actionRulesService = require('../../server/services/actionRulesService')
-const actionsService = require('../../server/services/actionsService')
-const actionID = 'FG1'
-const ruleID1 = 3
-const ruleID2 = 5
-const enabled = false
+
+const mockActionID = 'FG1'
+const mockRuleID = 1
+const mockEnabledChange = false
+
+jest.mock(
+  '../../data/rules.json',
+  () => ([
+    {
+      id: 1,
+      description: 'Mock rule 1',
+      enabled: true,
+      facts: []
+    }
+  ])
+)
 
 describe('actionRulesService', () => {
-  test('action rules service returns an object', async () => {
-    const rule = await actionRulesService.update(actionID, ruleID1, enabled)
-    expect((rule instanceof Object)).toEqual(true)
+  test('action rules service returns empty object for unknown id', async () => {
+    const rule = await actionRulesService.update(mockActionID, -1, false)
+    expect(rule).toEqual(expect.any(Object))
   })
 
   test('action rules service returns a rule object containing given id and enabled state', async () => {
-    const rule = await actionRulesService.update(actionID, ruleID1, enabled)
-    expect(rule).toEqual(
-      expect.objectContaining({
-        id: ruleID1,
-        enabled: enabled
-      })
-    )
+    const rule = await actionRulesService.update(mockActionID, mockRuleID, mockEnabledChange)
+    expect(rule).toMatchObject({ id: mockRuleID, enabled: mockEnabledChange })
   })
 
-  test('action rules service changes to rule enabled persist on multiple calls', async () => {
-    await actionRulesService.update(actionID, ruleID1, enabled)
-    await actionRulesService.update(actionID, ruleID2, enabled)
-    const actions = await actionsService.get()
-    const rules = actions.find(action => action.id === actionID).rules
-
-    expect(rules).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ id: ruleID1, enabled: enabled }),
-        expect.objectContaining({ id: ruleID2, enabled: enabled })
-      ])
-    )
+  afterAll(() => {
+    jest.unmock('../../data/rules.json')
   })
 })

--- a/test/services/actionRulesService.test.js
+++ b/test/services/actionRulesService.test.js
@@ -1,0 +1,21 @@
+const actionRulesService = require('../../server/services/actionRulesService')
+const actionID = 'FG1'
+const ruleID = 3
+const enabled = false
+
+describe('actionRulesService', () => {
+  test('action rules service returns an object', async () => {
+    const rule = await actionRulesService.update(actionID, ruleID, enabled)
+    expect((rule instanceof Object)).toEqual(true)
+  })
+
+  test('action rules service returns a rule object containing given id and enabled state', async () => {
+    const rule = await actionRulesService.update(actionID, ruleID, enabled)
+    expect(rule).toEqual(
+      expect.objectContaining({
+        id: ruleID,
+        enabled: enabled
+      })
+    )
+  })
+})

--- a/test/services/actionRulesService.test.js
+++ b/test/services/actionRulesService.test.js
@@ -1,21 +1,37 @@
 const actionRulesService = require('../../server/services/actionRulesService')
+const actionsService = require('../../server/services/actionsService')
 const actionID = 'FG1'
-const ruleID = 3
+const ruleID1 = 3
+const ruleID2 = 5
 const enabled = false
 
 describe('actionRulesService', () => {
   test('action rules service returns an object', async () => {
-    const rule = await actionRulesService.update(actionID, ruleID, enabled)
+    const rule = await actionRulesService.update(actionID, ruleID1, enabled)
     expect((rule instanceof Object)).toEqual(true)
   })
 
   test('action rules service returns a rule object containing given id and enabled state', async () => {
-    const rule = await actionRulesService.update(actionID, ruleID, enabled)
+    const rule = await actionRulesService.update(actionID, ruleID1, enabled)
     expect(rule).toEqual(
       expect.objectContaining({
-        id: ruleID,
+        id: ruleID1,
         enabled: enabled
       })
+    )
+  })
+
+  test('action rules service changes to rule enabled persist on multiple calls', async () => {
+    await actionRulesService.update(actionID, ruleID1, enabled)
+    await actionRulesService.update(actionID, ruleID2, enabled)
+    const actions = await actionsService.get()
+    const rules = actions.find(action => action.id === actionID).rules
+
+    expect(rules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: ruleID1, enabled: enabled }),
+        expect.objectContaining({ id: ruleID2, enabled: enabled })
+      ])
     )
   })
 })

--- a/test/services/parcelService.test.js
+++ b/test/services/parcelService.test.js
@@ -2,14 +2,14 @@ const parcelService = require('../../server/services/parcelService')
 
 jest.mock(
   '../../data/parcels.json',
-  () => ([{ parcelRef: 'AB74445736' }])
+  () => ([{ ref: 'AB74445736' }])
 )
 
 describe('parcelService', () => {
   const parcelShape = {
     // Match known Parcel Ref format: start with two alphabetical characters
     // followed by eight numeric characters
-    parcelRef: expect.stringMatching(new RegExp('^[A-Za-z]{2}[0-9]{8}$'))
+    ref: expect.stringMatching(new RegExp('^[A-Za-z]{2}[0-9]{8}$'))
   }
 
   afterAll(() => {
@@ -38,7 +38,7 @@ describe('parcelService', () => {
     test('returns a single matching parcel object', () => {
       const result = parcelService.getByRef('AB74445736')
 
-      expect(result).toEqual({ parcelRef: 'AB74445736' })
+      expect(result).toEqual({ ref: 'AB74445736' })
     })
 
     test('returns null if the requested parcel is not found', () => {

--- a/test/services/rulesService.test.js
+++ b/test/services/rulesService.test.js
@@ -1,13 +1,70 @@
-
 const rulesService = require('../../server/services/rulesService')
+
+jest.mock(
+  '../../data/rules.json',
+  () => ([
+    {
+      id: 1,
+      description: 'Mock rule 1',
+      enabled: true,
+      facts: []
+    },
+    {
+      id: 2,
+      description: 'Mock rule 2',
+      enabled: false,
+      facts: []
+    },
+    {
+      id: 3,
+      description: 'Mock rule 3',
+      enabled: true,
+      facts: []
+    }
+  ])
+)
+
 describe('rulesService', () => {
-  test('rules service returns an array', async () => {
+  const ruleID1 = 1
+  const ruleID2 = 2
+  const enabled1 = false
+  const enabled2 = true
+
+  afterAll(() => {
+    jest.unmock('../../data/rules.json')
+  })
+
+  test('rules service get returns an array', async () => {
     const rules = await rulesService.get()
     expect(Array.isArray(rules)).toEqual(true)
   })
 
-  test('rules service returns an array where the first element has an id of 1', async () => {
+  test('rules service get returns an array where the first element has an id of 1', async () => {
     const rules = await rulesService.get()
     expect(rules[0]).toMatchObject({ id: 1 })
+  })
+
+  test('rules service updateRuleEnabled returns empty object for unknown id', async () => {
+    const rule = await rulesService.updateRuleEnabled(-1, false)
+    expect(rule).toEqual(expect.any(Object))
+  })
+
+  test('rules service updateRuleEnabled returns updated rule object given known id', async () => {
+    const rule = await rulesService.updateRuleEnabled(ruleID1, enabled1)
+    expect(rule).toMatchObject({ id: ruleID1, enabled: enabled1 })
+  })
+
+  test('rules service updateRuleEnabled changes persist on multiple calls', async () => {
+    await rulesService.updateRuleEnabled(ruleID1, enabled1)
+    await rulesService.updateRuleEnabled(ruleID2, enabled2)
+    const rules = await rulesService.get()
+
+    expect(rules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: ruleID1, enabled: enabled1 }),
+        expect.objectContaining({ id: ruleID2, enabled: enabled2 }),
+        expect.objectContaining({ id: 3, enabled: true })
+      ])
+    )
   })
 })

--- a/test/services/rulesService.test.js
+++ b/test/services/rulesService.test.js
@@ -34,27 +34,27 @@ describe('rulesService', () => {
     jest.unmock('../../data/rules.json')
   })
 
-  test('rules service get returns an array', async () => {
+  test('get returns an array', async () => {
     const rules = await rulesService.get()
     expect(Array.isArray(rules)).toEqual(true)
   })
 
-  test('rules service get returns an array where the first element has an id of 1', async () => {
+  test('get returns an array where the first element has an id of 1', async () => {
     const rules = await rulesService.get()
     expect(rules[0]).toMatchObject({ id: 1 })
   })
 
-  test('rules service updateRuleEnabled returns empty object for unknown id', async () => {
+  test('updateRuleEnabled returns null for unknown id', async () => {
     const rule = await rulesService.updateRuleEnabled(-1, false)
-    expect(rule).toEqual(expect.any(Object))
+    expect(rule).toBeNull()
   })
 
-  test('rules service updateRuleEnabled returns updated rule object given known id', async () => {
+  test('updateRuleEnabled returns updated rule object given known id', async () => {
     const rule = await rulesService.updateRuleEnabled(ruleID1, enabled1)
     expect(rule).toMatchObject({ id: ruleID1, enabled: enabled1 })
   })
 
-  test('rules service updateRuleEnabled changes persist on multiple calls', async () => {
+  test('changes persist on multiple calls to updateRuleEnabled', async () => {
     await rulesService.updateRuleEnabled(ruleID1, enabled1)
     await rulesService.updateRuleEnabled(ruleID2, enabled2)
     const rules = await rulesService.get()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FCEP-58

Set the enabled state of action rules so they can be configured from front-end admin pages