### PR TITLE
All rules are run because rules engine isn't cleared before each run

### DIFF
--- a/server/actions/fencing.js
+++ b/server/actions/fencing.js
@@ -15,6 +15,7 @@ module.exports = {
     const rulesPass = () => {
       rulesPassed = true
     }
+    rulesEngine.resetEngine()
     await rulesEngine.doFullRun(rules, [landParcel], { requestedLength: options.quantity }, rulesPass)
     return rulesPassed
   }

--- a/test/actions/fencing.test.js
+++ b/test/actions/fencing.test.js
@@ -114,6 +114,11 @@ describe('Fencing action tests', () => {
       expect.any(Function)
     )
   })
+
+  test('resets rules engine when doing full run', async () => {
+    await fencing.isEligible({}, { quantity: 1 })
+    expect(rulesEngine.resetEngine).toHaveBeenCalled()
+  })
 })
 
 const generateAction = (id, numberOfRules) => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FCEP-89

When the fencing action performs a full run, rules from previous runs
are also used