### PR TITLE
Allow eligibility rules to run in isolation

### DIFF
--- a/data/rules.json
+++ b/data/rules.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 1,
-    "types": ["prevalidation"],
+    "type": "prevalidation",
     "groupname": "Perimeter",
     "description": "Proposed fence length is longer than Total Parcel Perimeter",
     "enabled": true,
@@ -21,7 +21,7 @@
   },
   {
     "id": 2,
-    "types": ["prevalidation"],
+    "type": "prevalidation",
     "groupname": "Perimeter",
     "description": "Proposed fence length is longer than Total Parcel Perimeter minus the Perimeter features",
     "enabled": true,
@@ -65,7 +65,7 @@
   },
   {
     "id": 3,
-    "types": ["prevalidation"],
+    "type": "prevalidation",
     "groupname": "Perimeter",
     "description": "Proposed fence length is longer than Total Parcel Perimeter minus the Perimeter features including the Tolerance",
     "enabled": true,
@@ -85,7 +85,7 @@
   },
   {
     "id": 4,
-    "types": ["eligibility"],
+    "type": "eligibility",
     "description": "Previous Action date is within the last 5 years",
     "enabled": true,
     "facts": [
@@ -103,7 +103,7 @@
   },
   {
     "id": 5,
-    "types": ["eligibility"],
+    "type": "eligibility",
     "description": "Parcel within SSSI",
     "enabled": true,
     "facts": [

--- a/server/rules-engine/index.js
+++ b/server/rules-engine/index.js
@@ -126,7 +126,7 @@ function RulesEngine () {
   this.Rule = Rule
 
   this.enabledEligibilityRules = function (rules) {
-    return rules.filter(rule => (('types' in rule) && rule.types.includes(enums.rulesTypes.eligibility) && rule.enabled))
+    return rules.filter(rule => rule.type === enums.rulesTypes.eligibility && rule.enabled)
   }
 
   this.enabledRules = function (rules) {

--- a/server/rules-engine/index.js
+++ b/server/rules-engine/index.js
@@ -83,6 +83,11 @@ const _setupFullRun = function (rulesJson, dataJson, successFunc) {
   this.loadCalculationRules(calcRules)
 }
 
+const _doEligibilityRun = async function (rules, data, passedFacts, successFunc) {
+  const eligibilityRules = this.enabledEligibilityRules(rules)
+  await this.doFullRun(eligibilityRules, data, passedFacts, successFunc)
+}
+
 const _doFullRun = async function (rulesJson, dataJson, passedFacts, successFunc) {
   const retVal = []
   this.setupFullRun(rulesJson, dataJson, successFunc)
@@ -156,6 +161,8 @@ function RulesEngine () {
   this.loadCalculationRules = _setupCalculationRules
 
   this.setupFullRun = _setupFullRun
+
+  this.doEligibilityRun = _doEligibilityRun
 
   this.doFullRun = _doFullRun
 

--- a/test/rules-engine/eligibilityrun.test.js
+++ b/test/rules-engine/eligibilityrun.test.js
@@ -9,11 +9,11 @@ describe('Eligibility rules test', () => {
   test('Only eligibility rules run', async () => {
     const testCases = [
       {
-        rules: [rulePreviousAction(['eligibility']), ruleSSSI(['prevalidation'])],
+        rules: [rulePreviousAction('eligibility'), ruleSSSI('prevalidation')],
         passingParcels: ['SD74445738', 'SD78379604', 'SD81525709']
       },
       {
-        rules: [rulePreviousAction(['eligibility']), ruleSSSI(['eligibility'])],
+        rules: [rulePreviousAction('eligibility'), ruleSSSI('eligibility')],
         passingParcels: ['SD78379604']
       }
     ]
@@ -33,9 +33,9 @@ describe('Eligibility rules test', () => {
   })
 })
 
-const rulePreviousAction = (types) => ({
+const rulePreviousAction = type => ({
   id: 1,
-  types,
+  type,
   description: 'Previous Action date is within the last 5 years',
   enabled: true,
   facts: [
@@ -52,9 +52,9 @@ const rulePreviousAction = (types) => ({
   }]
 })
 
-const ruleSSSI = (types) => ({
+const ruleSSSI = type => ({
   id: 2,
-  types,
+  type,
   description: 'Parcel within SSSI',
   enabled: true,
   facts: [

--- a/test/rules-engine/eligibilityrun.test.js
+++ b/test/rules-engine/eligibilityrun.test.js
@@ -1,0 +1,71 @@
+const rulesEngine = require('../../server/rules-engine')
+const parcelsTestData = require('./test-data/parcels-fulltest.json')
+
+describe('Eligibility rules test', () => {
+  beforeEach(() => {
+    rulesEngine.resetEngine()
+  })
+
+  test('Only eligibility rules run', async () => {
+    const testCases = [
+      {
+        rules: [rulePreviousAction(['eligibility']), ruleSSSI(['prevalidation'])],
+        passingParcels: ['SD74445738', 'SD78379604', 'SD81525709']
+      },
+      {
+        rules: [rulePreviousAction(['eligibility']), ruleSSSI(['eligibility'])],
+        passingParcels: ['SD78379604']
+      }
+    ]
+    for (const testCase of testCases) {
+      const acceptedParcels = []
+      const successFunc = async (event, almanac, ruleResult) => {
+        const ref = await almanac.factValue('ref')
+        acceptedParcels.push(ref)
+      }
+      rulesEngine.resetEngine()
+      await rulesEngine.doEligibilityRun(testCase.rules, parcelsTestData, {}, successFunc)
+      expect(acceptedParcels).toHaveLength(testCase.passingParcels.length)
+      expect(acceptedParcels).toEqual(
+        expect.arrayContaining(testCase.passingParcels)
+      )
+    }
+  })
+})
+
+const rulePreviousAction = (types) => ({
+  id: 1,
+  types,
+  description: 'Previous Action date is within the last 5 years',
+  enabled: true,
+  facts: [
+    {
+      id: 'previousActions',
+      description: 'Previous Action Dates'
+    }
+  ],
+  conditions: [{
+    fact: 'previousActions',
+    path: '$..date',
+    operator: 'lessThan5Years',
+    value: '2020-01-20T00:00:01.000Z'
+  }]
+})
+
+const ruleSSSI = (types) => ({
+  id: 2,
+  types,
+  description: 'Parcel within SSSI',
+  enabled: true,
+  facts: [
+    {
+      id: 'SSSI',
+      description: 'Parcel in SSSI area'
+    }
+  ],
+  conditions: [{
+    fact: 'SSSI',
+    operator: 'notEqual',
+    value: true
+  }]
+})

--- a/test/rules-engine/test-data/rules-actiondate.json
+++ b/test/rules-engine/test-data/rules-actiondate.json
@@ -45,7 +45,7 @@
   },
   {
     "id": 4,
-    "types": ["eligibility"],
+    "type": "eligibility",
     "description": "Previous Action date is within the last 5 years",
     "enabled": true,
     "facts": [
@@ -63,7 +63,7 @@
   },
   {
     "id": 5,
-    "types": ["eligibility"],
+    "type": "eligibility",
     "description": "Parcel within SSSI",
     "enabled": false,
     "facts": [

--- a/test/rules-engine/test-data/rules-fulltest.json
+++ b/test/rules-engine/test-data/rules-fulltest.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 1,
-    "types": ["prevalidation"],
+    "type": "prevalidation",
     "groupname": "Perimeter",
     "description": "Proposed fence length is longer than Total Parcel Perimeter",
     "enabled": false,
@@ -21,7 +21,7 @@
   },
   {
     "id": 2,
-    "types": ["prevalidation"],
+    "type": "prevalidation",
     "groupname": "Perimeter",
     "description": "Proposed fence length is longer than Total Parcel Perimeter minus the Perimeter features",
     "enabled": true,
@@ -65,7 +65,7 @@
   },
   {
     "id": 3,
-    "types": ["prevalidation"],
+    "type": "prevalidation",
     "groupname": "Perimeter",
     "description": "Proposed fence length is longer than Total Parcel Perimeter minus the Perimeter features including the Tolerance",
     "enabled": false,
@@ -85,7 +85,7 @@
   },
   {
     "id": 4,
-    "types": ["eligibility"],
+    "type": "eligibility",
     "description": "Previous Action date is within the last 5 years",
     "enabled": true,
     "facts": [
@@ -103,7 +103,7 @@
   },
   {
     "id": 5,
-    "types": ["eligibility"],
+    "type": "eligibility",
     "description": "Parcel within SSSI",
     "enabled": false,
     "facts": [

--- a/test/rules-engine/test-data/rules-index.json
+++ b/test/rules-engine/test-data/rules-index.json
@@ -45,7 +45,7 @@
   },
   {
     "id": 4,
-    "types": ["eligibility"],
+    "type": "eligibility",
     "description": "Previous Action date is within the last 5 years",
     "enabled": true,
     "facts": [
@@ -57,7 +57,7 @@
   },
   {
     "id": 5,
-    "types": ["eligibility"],
+    "type": "eligibility",
     "description": "Parcel within SSSI",
     "enabled": true,
     "facts": [

--- a/test/rules-engine/test-data/rules-prevalidation.json
+++ b/test/rules-engine/test-data/rules-prevalidation.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 1,
-    "types": ["prevalidation"],
+    "type": "prevalidation",
     "groupname": "Perimeter",
     "description": "Proposed fence length is longer than Total Parcel Perimeter",
     "enabled": false,
@@ -14,7 +14,7 @@
   },
   {
     "id": 2,
-    "types": ["prevalidation"],
+    "type": "prevalidation",
     "groupname": "Perimeter",
     "description": "Proposed fence length is longer than Total Parcel Perimeter minus the Perimeter features",
     "enabled": true,
@@ -58,7 +58,7 @@
   },
   {
     "id": 3,
-    "types": ["prevalidation"],
+    "type": "prevalidation",
     "groupname": "Perimeter",
     "description": "Proposed fence length is longer than Total Parcel Perimeter minus the Perimeter features including the Tolerance",
     "enabled": false,
@@ -78,7 +78,7 @@
   },
   {
     "id": 4,
-    "types": ["eligibility"],
+    "type": "eligibility",
     "description": "Previous Action date is within the last 5 years",
     "enabled": false,
     "facts": [
@@ -96,7 +96,7 @@
   },
   {
     "id": 5,
-    "types": ["eligibility"],
+    "type": "eligibility",
     "description": "Parcel within SSSI",
     "enabled": false,
     "facts": [

--- a/test/rules-engine/test-data/rules-sssi.json
+++ b/test/rules-engine/test-data/rules-sssi.json
@@ -45,7 +45,7 @@
   },
   {
     "id": 4,
-    "types": ["eligibility"],
+    "type": "eligibility",
     "description": "Previous Action date is within the last 5 years",
     "enabled": true,
     "facts": [
@@ -57,7 +57,7 @@
   },
   {
     "id": 5,
-    "types": ["eligibility"],
+    "type": "eligibility",
     "description": "Parcel within SSSI",
     "enabled": true,
     "facts": [

--- a/test/services/actionService.test.js
+++ b/test/services/actionService.test.js
@@ -8,14 +8,24 @@ const actionShape = expect.objectContaining({
   description: expect.any(String),
   rules: expect.arrayContaining([expect.objectContaining({
     id: expect.any(Number),
+    type: expect.any(String),
     description: expect.any(String),
-    enabled: expect.any(Boolean)
+    enabled: expect.any(Boolean),
+    facts: expect.arrayContaining([expect.objectContaining({
+      description: expect.any(String)
+    })])
   })])
 })
 
 describe('actionsService', () => {
   beforeEach(() => {
-    rulesService.get.mockReturnValue([{ id: 1, description: '', enabled: true }])
+    rulesService.get.mockReturnValue([{
+      id: 1,
+      description: '',
+      enabled: true,
+      type: '',
+      facts: [{ description: '' }]
+    }])
   })
 
   test('get returns an array of actions', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FCEP-66

Change to allow an isolated run of eligibility rules by the rules engine