### PR TITLE
New endpoint to return quantity bounds

### DIFF
--- a/data/actions.json
+++ b/data/actions.json
@@ -40,7 +40,7 @@
     "input": {
       "unit": "hectare",
       "description": "claim area",
-      "lowerbound": 2
+      "lowerbound": 0.1
     },
     "rules": [
       {

--- a/data/actions.json
+++ b/data/actions.json
@@ -3,6 +3,7 @@
     "id": "FG1",
     "description": "Fencing",
     "rate": 4,
+    "pre-check": true,
     "rules": [
       {
         "id": 1,
@@ -30,6 +31,7 @@
     "id": "SW6",
     "description": "Winter cover crops",
     "rate": 114,
+    "pre-check": true,
     "rules": [
       {
         "id": 5,

--- a/data/actions.json
+++ b/data/actions.json
@@ -4,6 +4,11 @@
     "description": "Fencing",
     "rate": 4,
     "pre-check": true,
+    "input": {
+      "unit": "metre",
+      "description": "fence length",
+      "lowerbound": 2
+    },
     "rules": [
       {
         "id": 1,
@@ -32,6 +37,11 @@
     "description": "Winter cover crops",
     "rate": 114,
     "pre-check": true,
+    "input": {
+      "unit": "hectare",
+      "description": "claim area",
+      "lowerbound": 2
+    },
     "rules": [
       {
         "id": 5,

--- a/data/actions.json
+++ b/data/actions.json
@@ -3,7 +3,7 @@
     "id": "FG1",
     "description": "Fencing",
     "rate": 4,
-    "pre-check": true,
+    "precheck": true,
     "input": {
       "unit": "metre",
       "description": "fence length",
@@ -36,7 +36,7 @@
     "id": "SW6",
     "description": "Winter cover crops",
     "rate": 114,
-    "pre-check": true,
+    "precheck": true,
     "input": {
       "unit": "hectare",
       "description": "claim area",

--- a/data/rules.json
+++ b/data/rules.json
@@ -41,7 +41,7 @@
         }
       },
       {
-        "id": "upperBound",
+        "id": "upperbound",
         "description": "Total usable perimeter length",
         "calculated": true,
         "calculation": {
@@ -57,7 +57,7 @@
     ],
     "conditions": [
       {
-        "fact": "upperBound",
+        "fact": "upperbound",
         "operator": "lessThanInclusive",
         "value": {
           "fact": "quantity"
@@ -142,7 +142,7 @@
         }
       },
       {
-        "id": "upperBound",
+        "id": "upperbound",
         "description": "Total usable area",
         "calculated": true,
         "calculation": {
@@ -158,7 +158,7 @@
     ],
     "conditions": [
       {
-        "fact": "upperBound",
+        "fact": "upperbound",
         "operator": "lessThanInclusive",
         "value": {
           "fact": "quantity"

--- a/data/rules.json
+++ b/data/rules.json
@@ -41,7 +41,7 @@
         }
       },
       {
-        "id": "usablePerimeter",
+        "id": "upperBound",
         "description": "Total usable perimeter length",
         "calculated": true,
         "calculation": {
@@ -57,7 +57,7 @@
     ],
     "conditions": [
       {
-        "fact": "usablePerimeter",
+        "fact": "upperBound",
         "operator": "lessThanInclusive",
         "value": {
           "fact": "quantity"
@@ -142,7 +142,7 @@
         }
       },
       {
-        "id": "usableArea",
+        "id": "upperBound",
         "description": "Total usable area",
         "calculated": true,
         "calculation": {
@@ -158,7 +158,7 @@
     ],
     "conditions": [
       {
-        "fact": "usableArea",
+        "fact": "upperBound",
         "operator": "lessThanInclusive",
         "value": {
           "fact": "quantity"

--- a/server/routes/parcelActions.js
+++ b/server/routes/parcelActions.js
@@ -27,10 +27,18 @@ module.exports = [{
   path: '/parcels/{parcelRef}/actions/{actionId}',
   handler: async (request, h) => {
     const { actionId, parcelRef } = request.params
-    const parcel = await parcelService.getByRef(parcelRef)
+    const parcel = parcelService.getByRef(parcelRef)
     const action = await actionsService.getByIdWithRules(actionId)
-    await rulesEngineHelper.fullRun(action, parcel, { quantity: 1 })
+    const runResult = await rulesEngineHelper.fullRun(action, parcel, { quantity: 1 })
+    const response = {
+      id: action.id,
+      description: action.description,
+      input: {
+        ...action.input,
+        upperbound: runResult.upperbound
+      }
+    }
 
-    return h.response({}).code(200)
+    return h.response(response).code(200)
   }
 }]

--- a/server/routes/parcelActions.js
+++ b/server/routes/parcelActions.js
@@ -1,7 +1,7 @@
 const validationSchema = require('../schema/parcelActions')
 const parcelActionsService = require('../services/parcelActionsService')
 
-module.exports = {
+module.exports = [{
   method: 'GET',
   path: '/parcels/{parcelRef}/actions',
   options: {
@@ -19,4 +19,10 @@ module.exports = {
       return h.response({ actions }).code(200)
     }
   }
-}
+}, {
+  method: 'GET',
+  path: '/parcels/{parcelRef}/actions/{actionId}',
+  handler: async (request, h) => {
+    return h.response({}).code(200)
+  }
+}]

--- a/server/routes/parcelActions.js
+++ b/server/routes/parcelActions.js
@@ -9,7 +9,7 @@ const quantityBoundsResponseBuilder = (action, runResult) => ({
   description: action.description,
   input: {
     ...action.input,
-    upperbound: runResult.upperbound && Math.round(runResult.upperbound.value * 100) / 100
+    upperbound: runResult.upperbound && Math.round((runResult.upperbound.value + Number.EPSILON) * 100) / 100
   }
 })
 

--- a/server/routes/parcelActions.js
+++ b/server/routes/parcelActions.js
@@ -38,7 +38,8 @@ module.exports = [{
     const { actionId, parcelRef } = request.params
     const parcel = parcelService.getByRef(parcelRef)
     const action = await actionsService.getByIdWithRules(actionId)
-    const runResult = await rulesEngineHelper.fullRun(action, parcel, { quantity: 1 })
+    const runData = { quantity: action.input.lowerbound }
+    const runResult = await rulesEngineHelper.fullRun(action, parcel, runData)
 
     return h.response(quantityBoundsResponseBuilder(action, runResult)).code(200)
   }

--- a/server/routes/parcelActions.js
+++ b/server/routes/parcelActions.js
@@ -1,5 +1,8 @@
 const validationSchema = require('../schema/parcelActions')
 const parcelActionsService = require('../services/parcelActionsService')
+const parcelService = require('../services/parcelService')
+const actionsService = require('../services/actionsService')
+const rulesEngineHelper = require('../rules-engine/helper')
 
 module.exports = [{
   method: 'GET',
@@ -23,6 +26,11 @@ module.exports = [{
   method: 'GET',
   path: '/parcels/{parcelRef}/actions/{actionId}',
   handler: async (request, h) => {
+    const { actionId, parcelRef } = request.params
+    const parcel = await parcelService.getByRef(parcelRef)
+    const action = await actionsService.getByIdWithRules(actionId)
+    await rulesEngineHelper.fullRun(action, parcel, { quantity: 1 })
+
     return h.response({}).code(200)
   }
 }]

--- a/server/routes/parcelActions.js
+++ b/server/routes/parcelActions.js
@@ -4,6 +4,15 @@ const parcelService = require('../services/parcelService')
 const actionsService = require('../services/actionsService')
 const rulesEngineHelper = require('../rules-engine/helper')
 
+const quantityBoundsResponseBuilder = (action, runResult) => ({
+  id: action.id,
+  description: action.description,
+  input: {
+    ...action.input,
+    upperbound: runResult.upperbound && Math.round(runResult.upperbound.value * 100) / 100
+  }
+})
+
 module.exports = [{
   method: 'GET',
   path: '/parcels/{parcelRef}/actions',
@@ -30,15 +39,7 @@ module.exports = [{
     const parcel = parcelService.getByRef(parcelRef)
     const action = await actionsService.getByIdWithRules(actionId)
     const runResult = await rulesEngineHelper.fullRun(action, parcel, { quantity: 1 })
-    const response = {
-      id: action.id,
-      description: action.description,
-      input: {
-        ...action.input,
-        upperbound: runResult.upperbound
-      }
-    }
 
-    return h.response(response).code(200)
+    return h.response(quantityBoundsResponseBuilder(action, runResult)).code(200)
   }
 }]

--- a/server/routes/paymentCalculation.js
+++ b/server/routes/paymentCalculation.js
@@ -22,7 +22,11 @@ module.exports = [
 
       const landParcel = await parcelService.getByRef(parcelRef)
       const action = await actionsService.getByIdWithRules(actionId)
-      const response = await rulesEngineHelper.fullRun(action, landParcel, actionData)
+      const runResult = await rulesEngineHelper.fullRun(action, landParcel, actionData)
+      const response = { eligible: runResult.eligible }
+      if (runResult.value) {
+        response.value = runResult.value
+      }
 
       return h.response(response).code(200)
     }

--- a/server/rules-engine/helper.js
+++ b/server/rules-engine/helper.js
@@ -4,9 +4,10 @@ const { quantityFactName, rateFactName } = require('./enums')
 async function fullRun (action, parcel, options) {
   const runResult = { eligible: false }
   rulesEngine.resetEngine()
-  const successCallback = () => {
+  const successCallback = (event, almanac, ruleResult) => {
     runResult.eligible = true
     runResult.value = action[rateFactName] * options[quantityFactName]
+    runResult.upperBound = almanac.factMap.get('upperBound')
   }
   await rulesEngine.doFullRun(action.rules, [parcel], options, successCallback)
   return runResult

--- a/server/rules-engine/helper.js
+++ b/server/rules-engine/helper.js
@@ -7,7 +7,7 @@ async function fullRun (action, parcel, options) {
   const successCallback = (event, almanac, ruleResult) => {
     runResult.eligible = true
     runResult.value = action[rateFactName] * options[quantityFactName]
-    runResult.upperBound = almanac.factMap.get('upperBound')
+    runResult.upperbound = almanac.factMap.get('upperbound')
   }
   await rulesEngine.doFullRun(action.rules, [parcel], options, successCallback)
   return runResult

--- a/test/routes/parcelActions.integration.test.js
+++ b/test/routes/parcelActions.integration.test.js
@@ -30,7 +30,7 @@ describe('GET /parcels/{parcelRef}/actions/{actionId}', () => {
       { parcelRef: 'SD81437506', expectedUpperbound: 431.6 },
       { parcelRef: 'SD81525709', expectedUpperbound: 540.4 }
     ]
-    await testParametersAreCorrectForAction(action, testCases)
+    await testOutputIsCorrect(action, testCases)
   })
 
   test('parcels have correct parameters for action SW6', async () => {
@@ -42,10 +42,10 @@ describe('GET /parcels/{parcelRef}/actions/{actionId}', () => {
       { parcelRef: 'SD81437506', expectedUpperbound: undefined },
       { parcelRef: 'SD81525709', expectedUpperbound: 1.49 }
     ]
-    await testParametersAreCorrectForAction(action, testCases)
+    await testOutputIsCorrect(action, testCases)
   })
 
-  const testParametersAreCorrectForAction = async (action, testCases) => {
+  const testOutputIsCorrect = async (action, testCases) => {
     for (const testCase of testCases) {
       const response = await server.inject(generateRequestOptions(testCase.parcelRef, action.id))
       const payload = JSON.parse(response.payload)

--- a/test/routes/parcelActions.integration.test.js
+++ b/test/routes/parcelActions.integration.test.js
@@ -1,0 +1,72 @@
+const createServer = require('../../server/createServer')
+const actions = require('../../data/actions')
+
+describe('GET /parcels/{parcelRef}/actions/{actionId}', () => {
+  let server
+
+  const generateRequestOptions = (
+    parcelRef,
+    actionId
+  ) => ({
+    method: 'GET',
+    url: `/parcels/${parcelRef}/actions/${actionId}`
+  })
+
+  beforeEach(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterEach(async () => {
+    await server.stop()
+  })
+
+  test('parcels have correct parameters for action FG1', async () => {
+    const action = actions.find(a => a.id === 'FG1')
+    const testCases = [
+      { parcelRef: 'SD74445738', expectedUpperbound: 739.3 },
+      { parcelRef: 'SD75492628', expectedUpperbound: undefined },
+      { parcelRef: 'SD78379604', expectedUpperbound: undefined },
+      { parcelRef: 'SD81437506', expectedUpperbound: 431.6 },
+      { parcelRef: 'SD81525709', expectedUpperbound: 540.4 }
+    ]
+    await testParametersAreCorrectForAction(action, testCases)
+  })
+
+  test('parcels have correct parameters for action SW6', async () => {
+    const action = actions.find(a => a.id === 'SW6')
+    const testCases = [
+      { parcelRef: 'SD74445738', expectedUpperbound: 1.56 },
+      { parcelRef: 'SD75492628', expectedUpperbound: 3.19 },
+      { parcelRef: 'SD78379604', expectedUpperbound: undefined },
+      { parcelRef: 'SD81437506', expectedUpperbound: undefined },
+      { parcelRef: 'SD81525709', expectedUpperbound: 1.49 }
+    ]
+    await testParametersAreCorrectForAction(action, testCases)
+  })
+
+  const testParametersAreCorrectForAction = async (action, testCases) => {
+    for (const testCase of testCases) {
+      const response = await server.inject(generateRequestOptions(testCase.parcelRef, action.id))
+      const payload = JSON.parse(response.payload)
+      expect(response.statusCode).toBe(200)
+      expect(payload).toEqual(
+        expect.objectContaining({
+          id: action.id,
+          description: action.description,
+          input: expect.objectContaining(generateExpectedInput(action, testCase.expectedUpperbound))
+        })
+      )
+    }
+  }
+
+  const generateExpectedInput = (action, upperbound) => {
+    const expectedInput = {
+      ...action.input
+    }
+    if (upperbound) {
+      expectedInput.upperbound = upperbound
+    }
+    return expectedInput
+  }
+})

--- a/test/routes/parcelActions.test.js
+++ b/test/routes/parcelActions.test.js
@@ -159,7 +159,8 @@ describe('GET /parcels/{parcelRef}/actions/{actionId}', () => {
       { upperbound: getUpperboundFact(40.2699999999999), expectedValue: 40.27 },
       { upperbound: getUpperboundFact(78.8383838383838), expectedValue: 78.84 },
       { upperbound: getUpperboundFact(44.4444444444444), expectedValue: 44.44 },
-      { upperbound: getUpperboundFact(55.5555555555555), expectedValue: 55.56 }
+      { upperbound: getUpperboundFact(55.5555555555555), expectedValue: 55.56 },
+      { upperbound: getUpperboundFact(1.005), expectedValue: 1.01 }
     ]
     for (const testCase of testCases) {
       const { upperbound, expectedValue } = testCase
@@ -180,7 +181,6 @@ describe('GET /parcels/{parcelRef}/actions/{actionId}', () => {
     }).not.toThrow()
   })
 
-  // also need test for action lowerbound being passed to rules runner, rather than 1...
   test('when initiating a rules run, the lowerbound from the action is used as the quantity', async () => {
     const testCases = [0.1, 1.2, 12, 82]
     for (const testCase of testCases) {

--- a/test/routes/parcelActions.test.js
+++ b/test/routes/parcelActions.test.js
@@ -62,3 +62,30 @@ describe('Parcel Actions route test', () => {
     await server.stop()
   })
 })
+
+describe('GET /parcels/{parcelRef}/actions/{actionId}', () => {
+  const createServer = require('../../server/createServer')
+  let server
+
+  const generateRequestOptions = (
+    parcelRef = 'AA1111',
+    actionId = 'aaa111'
+  ) => ({
+    method: 'GET',
+    url: `/parcels/${parcelRef}/actions/${actionId}`
+  })
+
+  beforeEach(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterEach(async () => {
+    await server.stop()
+  })
+
+  test('responds with status code 200', async () => {
+    const response = await server.inject(generateRequestOptions())
+    expect(response.statusCode).toBe(200)
+  })
+})

--- a/test/routes/paymentCalculation.integration.test.js
+++ b/test/routes/paymentCalculation.integration.test.js
@@ -1,6 +1,6 @@
 const createServer = require('../../server/createServer')
 
-describe('POST /parcels/{parcelRef/actions/{actionId}/payment-calculation', () => {
+describe('POST /parcels/{parcelRef}/actions/{actionId}/payment-calculation', () => {
   let server
 
   const generateRequestOptions = (

--- a/test/routes/paymentCalculation.test.js
+++ b/test/routes/paymentCalculation.test.js
@@ -98,12 +98,12 @@ describe('POST /parcels/{parcelRef}/actions/{actionId}/payment-calculation', () 
 
   test('omits keys other than value and eligible from response', async () => {
     const expectedResponse = { eligible: true, value: 31.8 }
-    const runResult = { ...expectedResponse, upperBound: 91.6 }
+    const runResult = { ...expectedResponse, upperbound: 91.6 }
     rulesEngineHelper.fullRun.mockResolvedValue(runResult)
 
     const response = await server.inject(generateRequestOptions())
     const responseData = JSON.parse(response.payload)
-    expect(Object.keys(responseData).includes('upperBound')).toBeFalsy()
+    expect(Object.keys(responseData).includes('upperbound')).toBeFalsy()
   })
 
   const getSampleAction = () => ({

--- a/test/routes/paymentCalculation.test.js
+++ b/test/routes/paymentCalculation.test.js
@@ -96,6 +96,16 @@ describe('POST /parcels/{parcelRef}/actions/{actionId}/payment-calculation', () 
     expect(Object.keys(responseData).includes('value')).toBeFalsy()
   })
 
+  test('omits keys other than value and eligible from response', async () => {
+    const expectedResponse = { eligible: true, value: 31.8 }
+    const runResult = { ...expectedResponse, upperBound: 91.6 }
+    rulesEngineHelper.fullRun.mockResolvedValue(runResult)
+
+    const response = await server.inject(generateRequestOptions())
+    const responseData = JSON.parse(response.payload)
+    expect(Object.keys(responseData).includes('upperBound')).toBeFalsy()
+  })
+
   const getSampleAction = () => ({
     id: 'action-1',
     rules: [

--- a/test/rules-engine/helper.test.js
+++ b/test/rules-engine/helper.test.js
@@ -31,12 +31,26 @@ describe('Rules engine helper', () => {
     }
   })
 
+  test('provides an upperBound fact when rules pass and almanac provides this fact', async () => {
+    const testCases = [
+      { almanac: getSampleAlmanac([['upperBound', 101.2]]), expectedResult: 101.2 },
+      { almanac: getSampleAlmanac([['upperBound', 87]]), expectedResult: 87 },
+      { almanac: getSampleAlmanac([['upperBound', 3]]), expectedResult: 3 }
+    ]
+    const sampleAction = getSampleAction()
+    for (const testCase of testCases) {
+      const runResult = await invokeRulesEngineHelperFullRun(
+        sampleAction, { quantity: sampleAction.lowerBound }, testCase.almanac)
+      expect(runResult.upperBound).toBe(testCase.expectedResult)
+    }
+  })
+
   test('resets rules engine', () => {
     rulesEngineHelper.fullRun(getSampleRules(), getSampleParcel(), { parameterValue: 1 })
     expect(rulesEngine.resetEngine).toHaveBeenCalled()
   })
 
-  const invokeRulesEngineHelperFullRun = (action, actionData) => {
+  const invokeRulesEngineHelperFullRun = (action, actionData, almanac = getSampleAlmanac()) => {
     let successCallback
     let dfrResolve
     const dfrPromise = new Promise((resolve, reject) => {
@@ -48,7 +62,7 @@ describe('Rules engine helper', () => {
     })
 
     const runPromise = rulesEngineHelper.fullRun(action, getSampleParcel(), actionData)
-    successCallback()
+    successCallback(undefined, almanac)
     dfrResolve()
     return runPromise
   }
@@ -63,6 +77,7 @@ describe('Rules engine helper', () => {
   const getSampleAction = (rate = 1) => ({
     id: 'action-1',
     description: 'Action 1',
+    lowerBound: 1,
     rate,
     rules: getSampleRules()
   })
@@ -89,4 +104,8 @@ describe('Rules engine helper', () => {
       }]
     }
   ]
+
+  const getSampleAlmanac = keyValues => ({
+    factMap: new Map(keyValues)
+  })
 })

--- a/test/rules-engine/helper.test.js
+++ b/test/rules-engine/helper.test.js
@@ -31,17 +31,17 @@ describe('Rules engine helper', () => {
     }
   })
 
-  test('provides an upperBound fact when rules pass and almanac provides this fact', async () => {
+  test('provides an upperbound fact when rules pass and almanac provides this fact', async () => {
     const testCases = [
-      { almanac: getSampleAlmanac([['upperBound', 101.2]]), expectedResult: 101.2 },
-      { almanac: getSampleAlmanac([['upperBound', 87]]), expectedResult: 87 },
-      { almanac: getSampleAlmanac([['upperBound', 3]]), expectedResult: 3 }
+      { almanac: getSampleAlmanac([['upperbound', 101.2]]), expectedResult: 101.2 },
+      { almanac: getSampleAlmanac([['upperbound', 87]]), expectedResult: 87 },
+      { almanac: getSampleAlmanac([['upperbound', 3]]), expectedResult: 3 }
     ]
     const sampleAction = getSampleAction()
     for (const testCase of testCases) {
       const runResult = await invokeRulesEngineHelperFullRun(
         sampleAction, { quantity: sampleAction.lowerBound }, testCase.almanac)
-      expect(runResult.upperBound).toBe(testCase.expectedResult)
+      expect(runResult.upperbound).toBe(testCase.expectedResult)
     }
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FCEP-98

New endpoint '/parcels/{parcelRef}/actions/{actionID}' to return
quantity bounds if pre-check is enabled for the Action